### PR TITLE
Widget styling and data structuring updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "java.compile.nullAnalysis.mode": "automatic"
+    "java.compile.nullAnalysis.mode": "automatic",
+    "cSpell.words": [
+        "haki"
+    ]
 }

--- a/lib/application/dummy.dart
+++ b/lib/application/dummy.dart
@@ -1,1 +1,0 @@
-// TODO: To be removed

--- a/lib/application/dummy_data.dart
+++ b/lib/application/dummy_data.dart
@@ -1,0 +1,71 @@
+import 'package:haki_hub/routes/routes.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+
+List<Map<String, dynamic>> civicEducationData = [
+  {
+    'title': 'Finance Bill 2024',
+    'description': 'Learn about the new finance bill.',
+    'icon': FluentIcons.book_coins_24_regular,
+  },
+  {
+    'title': 'Data Protection Act',
+    'description': 'Learn about the 2019 data protection act',
+    'icon': FluentIcons.shield_lock_24_regular,
+  },
+  {
+    'title': 'Protesting Rights',
+    'description': 'Learn about your constitutional right.',
+    'icon': FluentIcons.people_community_24_regular,
+  },
+  {
+    'title': 'ICT Bill',
+    'description': 'Learn about the ICT bill',
+    'icon': FluentIcons.book_open_globe_24_regular,
+  },
+];
+
+List<Map<String, dynamic>> resourcesData = [
+  {
+    'title': 'First Aid',
+    'description': 'Get help with tear gas exposure, injury and more.',
+    'icon': FluentIcons.doctor_24_regular,
+  },
+  {
+    'title': 'Mental Health Support',
+    'description': 'Get help with any distress including trauma, panic...',
+    'icon': FluentIcons.heart_pulse_24_regular,
+  },
+  {
+    'title': 'Communities',
+    'description': 'Find communities around civic education.',
+    'icon': FluentIcons.building_people_24_regular,
+  },
+  {
+    'title': 'Downloads',
+    'description': 'Get relevant documents, media...',
+    'icon': FluentIcons.attach_24_regular,
+  },
+];
+
+List<Map<String, dynamic>> helplinesData = [
+  {
+    'title': 'Police Brutality Helplines',
+    'description': 'Report incidents of police brutality.',
+    'icon': FluentIcons.person_running_20_regular,
+    'isTertiaryColor': true,
+    'route': AppRoutes.policeHelplinePageRoute
+  },
+  {
+    'title': 'Medic Helplines',
+    'description': 'Request assistance from ambulance services.',
+    'icon': FluentIcons.briefcase_medical_24_regular,
+    'isSecondaryColor': true,
+    'route': AppRoutes.ambulanceHelplinePageRoute
+  },
+  {
+    'title': 'Legal Aid Helplines',
+    'description': 'Connect with pro bono legal assistance.',
+    'icon': FluentIcons.gavel_24_regular,
+    'route': AppRoutes.lawHelplinePageRoute
+  },
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+
+import 'package:haki_hub/routes/route_generator.dart';
 import 'package:haki_hub/domain/value_objects/app_colors.dart';
 import 'package:haki_hub/presentation/home/widgets/bottom_navigation.dart';
-import 'package:haki_hub/routes/route_generator.dart';
 
 void main() {
   runApp(

--- a/lib/presentation/helplines/pages/helpline_page.dart
+++ b/lib/presentation/helplines/pages/helpline_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:haki_hub/domain/value_objects/asset_strings.dart';
+
+import 'package:haki_hub/application/dummy_data.dart';
 import 'package:haki_hub/domain/value_objects/spaces.dart';
 import 'package:haki_hub/domain/value_objects/strings.dart';
-import 'package:haki_hub/presentation/shared/app_scaffold.dart';
 import 'package:haki_hub/presentation/shared/info_card.dart';
-import 'package:haki_hub/routes/routes.dart';
+import 'package:haki_hub/presentation/shared/app_scaffold.dart';
 
 class HelplinePage extends StatelessWidget {
   const HelplinePage({super.key});
@@ -49,37 +49,28 @@ class HelplinePage extends StatelessWidget {
                 ),
               ),
               mediumVerticalSizedBox,
-              InfoCard(
-                  assetName: ambulanceSvg,
-                  isSecondaryColor: true,
-                  isFullLength: true,
-                  hasBorder: true,
-                  title: medicalEmergencyString,
-                  description: medicalEmergencyCardDescription,
-                  onTap: () => Navigator.of(context)
-                      .pushNamed(AppRoutes.ambulanceHelplinePageRoute)),
-              size15VerticalSizedBox,
-              InfoCard(
-                assetName: nine11Svg,
-                isTertiaryColor: true,
-                isFullLength: true,
-                hasBorder: true,
-                title: policeBrutalityTitleString,
-                description: policeBrutalityCardDescription,
-                onTap: () => Navigator.of(context)
-                    .pushNamed(AppRoutes.policeHelplinePageRoute),
+              ListView.builder(
+                shrinkWrap: true,
+                itemCount: helplinesData.length,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (context, index) {
+                  var item = helplinesData[index];
+                  bool hasTertiaryOrSecondary = item.containsKey('isTertiaryColor') || item.containsKey('isSecondaryColor');
+                  bool isTertiary = hasTertiaryOrSecondary ? item['isTertiaryColor'] ?? false : false;
+                  bool isSecondary = hasTertiaryOrSecondary ? item['isSecondaryColor'] ?? false : false;
+
+                  return InfoCard(
+                    hasBorder: true,
+                    isFullLength: true,
+                    isTertiaryColor: isTertiary,
+                    isSecondaryColor: isSecondary,
+                    icon: item['icon'],
+                    title: item['title'],
+                    description: item['description'],
+                    onTap: () => Navigator.of(context).pushNamed(item['route']),
+                  );
+                }
               ),
-              size15VerticalSizedBox,
-              InfoCard(
-                assetName: buildingSvg,
-                isFullLength: true,
-                hasBorder: true,
-                title: lawyerAssistanceString,
-                description: lawyerAssistanceCardDescription,
-                onTap: () => Navigator.of(context)
-                    .pushNamed(AppRoutes.lawHelplinePageRoute),
-              ),
-              size15VerticalSizedBox,
             ],
           ),
         ),

--- a/lib/presentation/home/pages/home_page.dart
+++ b/lib/presentation/home/pages/home_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 
-import 'package:haki_hub/routes/routes.dart';
+import 'package:haki_hub/application/dummy_data.dart';
 import 'package:haki_hub/domain/value_objects/utils.dart';
 import 'package:haki_hub/domain/value_objects/spaces.dart';
 import 'package:haki_hub/domain/value_objects/strings.dart';
 import 'package:haki_hub/presentation/shared/info_card.dart';
-import 'package:haki_hub/domain/value_objects/app_colors.dart';
 import 'package:haki_hub/presentation/shared/app_scaffold.dart';
+import 'package:haki_hub/presentation/shared/section_header.dart';
 import 'package:haki_hub/domain/value_objects/asset_strings.dart';
 import 'package:haki_hub/presentation/home/widgets/carousel_card.dart';
 
@@ -56,199 +56,96 @@ class HomePage extends StatelessWidget {
             ),
             const SizedBox(height: 26),
             // Civic Education Section
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 10),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Column(
-                children: <Widget>[
-                  // Header
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        civicEducationString,
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      Text(
-                        viewAllString,
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.secondaryColor500,
-                        ),
-                      )
-                    ],
+                children: [
+                  const SectionHeader(title: civicEducationString),
+                  size15VerticalSizedBox,
+                  GridView.builder(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 10,
+                      mainAxisSpacing: 10,
+                    ),
+                    itemCount: civicEducationData.length,
+                    itemBuilder: (context, index) {
+                      var item = civicEducationData[index];
+                      return InfoCard(
+                        icon: item['icon'],
+                        isTertiaryColor: true,
+                        title: item['title'],
+                        description: item['description'],
+                      );
+                    },
                   ),
-                  SizedBox(height: 14),
-                  // Card Items
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      InfoCard(
-                        icon: Icons.money,
-                        isTertiaryColor: true,
-                        title: financeBill2024String,
-                        description: financeBillCardDescription,
-                      ),
-                      InfoCard(
-                        icon: Icons.lock,
-                        isTertiaryColor: true,
-                        title: dataProtectionActString,
-                        description: dataProtectionCardDescription,
-                      ),
-                    ],
-                  ),
-                  SizedBox(height: 14),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      InfoCard(
-                        icon: Icons.accessibility,
-                        isTertiaryColor: true,
-                        title: protestingRightsString,
-                        description: protestingRightsCardDescription,
-                      ),
-                      InfoCard(
-                        icon: Icons.language,
-                        isTertiaryColor: true,
-                        title: ictBillString,
-                        description: ictBillCardDescription,
-                      ),
-                    ],
-                  )
                 ],
               ),
             ),
-            const SizedBox(
-              height: 26,
-            ),
+            const SizedBox( height: 25),
+
             // Resources Section
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Column(
                 children: [
-                  // Header
-                  const Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        resourcesString,
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      Text(
-                        viewAllString,
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.secondaryColor500,
-                        ),
-                      )
-                    ],
-                  ),
+                  const SectionHeader(title: resourcesString),
                   size15VerticalSizedBox,
                   // Card Items
-                  const Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      InfoCard(
-                        icon: Icons.health_and_safety,
+                  GridView.builder(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 10,
+                      mainAxisSpacing: 10,
+                    ),
+                    itemCount: resourcesData.length,
+                    itemBuilder: (context, index) {
+                      var item = resourcesData[index];
+                      return InfoCard(
+                        icon: item['icon'],
                         isSecondaryColor: true,
-                        title: firstAidCardDescription,
-                        description: firstAidCardDescription,
-                      ),
-                      InfoCard(
-                        icon: Icons.psychology,
-                        isSecondaryColor: true,
-                        title: mentalHealthString,
-                        description: mentalHealthCardDescription,
-                      ),
-                    ],
+                        title: item['title'],
+                        description: item['description'],
+                      );
+                    },
                   ),
-                  size15VerticalSizedBox,
-                  const Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      InfoCard(
-                        icon: Icons.group,
-                        isSecondaryColor: true,
-                        title: communitiesString,
-                        description: communitiesCardDescription,
-                      ),
-                      InfoCard(
-                        icon: Icons.attach_file,
-                        isSecondaryColor: true,
-                        title: downloadsString,
-                        description: downloadsCardDescription,
-                      ),
-                    ],
-                  )
                 ],
               ),
             ),
-            const SizedBox(
-              height: 26,
-            ),
+            const SizedBox(height: 26),
+
+            // Resources Section
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Column(
                 children: [
-                  // Header
-                  const Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        resourcesString,
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      Text(
-                        viewAllString,
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.secondaryColor500,
-                        ),
-                      )
-                    ],
-                  ),
+                  const SectionHeader(title: resourcesString),
                   size15VerticalSizedBox,
-                  InfoCard(
-                    assetName: nine11Svg,
-                    isTertiaryColor: true,
-                    isFullLength: true,
-                    hasBorder: true,
-                    title: policeBrutalityTitleString,
-                    description: policeBrutalityCardDescription,
-                    onTap: () => Navigator.of(context).pushNamed(
-                      AppRoutes.policeHelplinePageRoute
-                    ),
-                  ),
-                  size15VerticalSizedBox,
-                  InfoCard(
-                    assetName: ambulanceSvg,
-                    isSecondaryColor: true,
-                    isFullLength: true,
-                    hasBorder: true,
-                    title: medicalEmergencyString,
-                    description: medicalEmergencyCardDescription,
-                    onTap: () => Navigator.of(context).pushNamed(
-                      AppRoutes.ambulanceHelplinePageRoute
-                    )
-                  ),
-                  size15VerticalSizedBox,
-                  InfoCard(
-                    assetName: buildingSvg,
-                    isFullLength: true,
-                    hasBorder: true,
-                    title: lawyerAssistanceString,
-                    description: lawyerAssistanceCardDescription,
-                    onTap: () => Navigator.of(context).pushNamed(
-                      AppRoutes.lawHelplinePageRoute
-                    ),
+                  ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: helplinesData.length,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemBuilder: (context, index) {
+                      var item = helplinesData[index];
+                      bool hasTertiaryOrSecondary = item.containsKey('isTertiaryColor') || item.containsKey('isSecondaryColor');
+                      bool isTertiary = hasTertiaryOrSecondary ? item['isTertiaryColor'] ?? false : false;
+                      bool isSecondary = hasTertiaryOrSecondary ? item['isSecondaryColor'] ?? false : false;
+
+                      return InfoCard(
+                        hasBorder: true,
+                        isFullLength: true,
+                        isTertiaryColor: isTertiary,
+                        isSecondaryColor: isSecondary,
+                        icon: item['icon'],
+                        title: item['title'],
+                        description: item['description'],
+                        onTap: () => Navigator.of(context).pushNamed(item['route']),
+                      );
+                    }
                   ),
                   size15VerticalSizedBox,
                 ],

--- a/lib/presentation/home/pages/home_page.dart
+++ b/lib/presentation/home/pages/home_page.dart
@@ -1,14 +1,15 @@
-import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
-import 'package:haki_hub/domain/value_objects/app_colors.dart';
-import 'package:haki_hub/domain/value_objects/asset_strings.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+
+import 'package:haki_hub/routes/routes.dart';
+import 'package:haki_hub/domain/value_objects/utils.dart';
 import 'package:haki_hub/domain/value_objects/spaces.dart';
 import 'package:haki_hub/domain/value_objects/strings.dart';
-import 'package:haki_hub/domain/value_objects/utils.dart';
-import 'package:haki_hub/presentation/home/widgets/carousel_card.dart';
-import 'package:haki_hub/presentation/shared/app_scaffold.dart';
 import 'package:haki_hub/presentation/shared/info_card.dart';
-import 'package:haki_hub/routes/routes.dart';
+import 'package:haki_hub/domain/value_objects/app_colors.dart';
+import 'package:haki_hub/presentation/shared/app_scaffold.dart';
+import 'package:haki_hub/domain/value_objects/asset_strings.dart';
+import 'package:haki_hub/presentation/home/widgets/carousel_card.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -20,9 +21,9 @@ class HomePage extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
+          children: [
             Stack(
-              children: <Widget>[
+              children: [
                 Image.asset(
                   backgroundBannerImage,
                   fit: BoxFit.cover,
@@ -35,16 +36,14 @@ class HomePage extends StatelessWidget {
                   child: Padding(
                     padding: const EdgeInsets.only(bottom: 10),
                     child: CarouselSlider(
-                      options: CarouselOptions(height: 110.0),
+                      options: CarouselOptions(height: 115.0),
                       items: carouselSliderItems.map((CarouselCard card) {
                         return Builder(
                           builder: (BuildContext context) {
                             return Container(
                               width: MediaQuery.of(context).size.width,
-                              margin:
-                                  const EdgeInsets.symmetric(horizontal: 5.0),
-                              decoration:
-                                  const BoxDecoration(color: Colors.amber),
+                              margin: const EdgeInsets.symmetric(horizontal: 5.0),
+                              decoration: const BoxDecoration(color: Colors.amber),
                               child: card,
                             );
                           },
@@ -55,9 +54,7 @@ class HomePage extends StatelessWidget {
                 ),
               ],
             ),
-            const SizedBox(
-              height: 26,
-            ),
+            const SizedBox(height: 26),
             // Civic Education Section
             const Padding(
               padding: EdgeInsets.symmetric(horizontal: 10),
@@ -66,7 +63,7 @@ class HomePage extends StatelessWidget {
                   // Header
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       Text(
                         civicEducationString,
                         style: TextStyle(
@@ -77,19 +74,17 @@ class HomePage extends StatelessWidget {
                       Text(
                         viewAllString,
                         style: TextStyle(
-                          fontSize: 20,
+                          fontSize: 14,
                           color: AppColors.secondaryColor500,
                         ),
                       )
                     ],
                   ),
-                  SizedBox(
-                    height: 14,
-                  ),
+                  SizedBox(height: 14),
                   // Card Items
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       InfoCard(
                         icon: Icons.money,
                         isTertiaryColor: true,
@@ -104,12 +99,10 @@ class HomePage extends StatelessWidget {
                       ),
                     ],
                   ),
-                  SizedBox(
-                    height: 14,
-                  ),
+                  SizedBox(height: 14),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       InfoCard(
                         icon: Icons.accessibility,
                         isTertiaryColor: true,
@@ -134,7 +127,7 @@ class HomePage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Column(
-                children: <Widget>[
+                children: [
                   // Header
                   const Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -149,7 +142,7 @@ class HomePage extends StatelessWidget {
                       Text(
                         viewAllString,
                         style: TextStyle(
-                          fontSize: 20,
+                          fontSize: 14,
                           color: AppColors.secondaryColor500,
                         ),
                       )
@@ -159,7 +152,7 @@ class HomePage extends StatelessWidget {
                   // Card Items
                   const Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       InfoCard(
                         icon: Icons.health_and_safety,
                         isSecondaryColor: true,
@@ -177,7 +170,7 @@ class HomePage extends StatelessWidget {
                   size15VerticalSizedBox,
                   const Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       InfoCard(
                         icon: Icons.group,
                         isSecondaryColor: true,
@@ -201,11 +194,11 @@ class HomePage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Column(
-                children: <Widget>[
+                children: [
                   // Header
                   const Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
+                    children: [
                       Text(
                         resourcesString,
                         style: TextStyle(
@@ -216,7 +209,7 @@ class HomePage extends StatelessWidget {
                       Text(
                         viewAllString,
                         style: TextStyle(
-                          fontSize: 20,
+                          fontSize: 14,
                           color: AppColors.secondaryColor500,
                         ),
                       )
@@ -230,19 +223,22 @@ class HomePage extends StatelessWidget {
                     hasBorder: true,
                     title: policeBrutalityTitleString,
                     description: policeBrutalityCardDescription,
-                    onTap: () => Navigator.of(context)
-                        .pushNamed(AppRoutes.policeHelplinePageRoute),
+                    onTap: () => Navigator.of(context).pushNamed(
+                      AppRoutes.policeHelplinePageRoute
+                    ),
                   ),
                   size15VerticalSizedBox,
                   InfoCard(
-                      assetName: ambulanceSvg,
-                      isSecondaryColor: true,
-                      isFullLength: true,
-                      hasBorder: true,
-                      title: medicalEmergencyString,
-                      description: medicalEmergencyCardDescription,
-                      onTap: () => Navigator.of(context)
-                          .pushNamed(AppRoutes.ambulanceHelplinePageRoute)),
+                    assetName: ambulanceSvg,
+                    isSecondaryColor: true,
+                    isFullLength: true,
+                    hasBorder: true,
+                    title: medicalEmergencyString,
+                    description: medicalEmergencyCardDescription,
+                    onTap: () => Navigator.of(context).pushNamed(
+                      AppRoutes.ambulanceHelplinePageRoute
+                    )
+                  ),
                   size15VerticalSizedBox,
                   InfoCard(
                     assetName: buildingSvg,
@@ -250,8 +246,9 @@ class HomePage extends StatelessWidget {
                     hasBorder: true,
                     title: lawyerAssistanceString,
                     description: lawyerAssistanceCardDescription,
-                    onTap: () => Navigator.of(context)
-                        .pushNamed(AppRoutes.lawHelplinePageRoute),
+                    onTap: () => Navigator.of(context).pushNamed(
+                      AppRoutes.lawHelplinePageRoute
+                    ),
                   ),
                   size15VerticalSizedBox,
                 ],

--- a/lib/presentation/home/widgets/bottom_navigation.dart
+++ b/lib/presentation/home/widgets/bottom_navigation.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+
 import 'package:haki_hub/domain/value_objects/app_colors.dart';
-import 'package:haki_hub/presentation/helplines/pages/helpline_page.dart';
-import 'package:haki_hub/presentation/content/pages/content_page.dart';
-import 'package:haki_hub/presentation/content/pages/updates_page.dart';
 import 'package:haki_hub/presentation/home/pages/home_page.dart';
+import 'package:haki_hub/presentation/content/pages/updates_page.dart';
+import 'package:haki_hub/presentation/content/pages/content_page.dart';
+import 'package:haki_hub/presentation/helplines/pages/helpline_page.dart';
 
 class BottomNavigation extends StatefulWidget {
   const BottomNavigation({super.key});
@@ -54,44 +56,44 @@ class _BottomNavigationState extends State<BottomNavigation> {
           destinations: const [
             NavigationDestination(
               icon: Icon(
-                Icons.home_outlined,
+                FluentIcons.home_24_regular,
                 color: AppColors.primaryColor400,
               ),
               selectedIcon: Icon(
-                Icons.home,
+                FluentIcons.home_24_filled,
                 color: Colors.white,
               ),
               label: 'Home',
             ),
             NavigationDestination(
               icon: Icon(
-                Icons.article_outlined,
+                FluentIcons.learning_app_24_regular,
                 color: AppColors.primaryColor400,
               ),
               selectedIcon: Icon(
-                Icons.article,
+                FluentIcons.learning_app_24_filled,
                 color: Colors.white,
               ),
               label: 'Content',
             ),
             NavigationDestination(
               icon: Icon(
-                Icons.update_outlined,
+                FluentIcons.arrow_rotate_clockwise_24_regular,
                 color: AppColors.primaryColor400,
               ),
               selectedIcon: Icon(
-                Icons.update,
+                FluentIcons.arrow_rotate_clockwise_24_filled,
                 color: Colors.white,
               ),
               label: 'Updates',
             ),
             NavigationDestination(
               icon: Icon(
-                Icons.help_outline,
+                FluentIcons.chat_bubbles_question_24_regular,
                 color: AppColors.primaryColor400,
               ),
               selectedIcon: Icon(
-                Icons.help,
+                FluentIcons.chat_bubbles_question_24_filled,
                 color: Colors.white,
               ),
               label: 'Helplines',

--- a/lib/presentation/home/widgets/carousel_card.dart
+++ b/lib/presentation/home/widgets/carousel_card.dart
@@ -30,7 +30,7 @@ class CarouselCard extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
+        children: [
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -60,14 +60,10 @@ class CarouselCard extends StatelessWidget {
               fontSize: 16,
             ),
           ),
-          const SizedBox(
-            height: 10,
-          ),
+          const SizedBox(height: 10),
           Text(
             subtitle,
-            style: const TextStyle(
-              fontSize: 12,
-            ),
+            style: const TextStyle(fontSize: 12),
           )
         ],
       ),

--- a/lib/presentation/home/widgets/carousel_card.dart
+++ b/lib/presentation/home/widgets/carousel_card.dart
@@ -36,14 +36,14 @@ class CarouselCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
               Container(
-                padding: const EdgeInsets.all(6),
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                 decoration: BoxDecoration(
                   color: chipColor,
-                  borderRadius: BorderRadius.circular(10),
+                  borderRadius: BorderRadius.circular(20),
                 ),
                 child: Text(
                   chipTitle,
-                  style: TextStyle(color: chipTitleColor),
+                  style: TextStyle(color: chipTitleColor, fontSize: 11),
                 ),
               ),
               Text(
@@ -63,7 +63,7 @@ class CarouselCard extends StatelessWidget {
           const SizedBox(height: 10),
           Text(
             subtitle,
-            style: const TextStyle(fontSize: 12),
+            style: const TextStyle(fontSize: 13),
           )
         ],
       ),

--- a/lib/presentation/shared/app_scaffold.dart
+++ b/lib/presentation/shared/app_scaffold.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:flutter/material.dart';
 import 'package:haki_hub/domain/value_objects/asset_strings.dart';
 
 class AppScaffold extends StatelessWidget {
@@ -13,17 +13,21 @@ class AppScaffold extends StatelessWidget {
   final String title;
   final Widget body;
   final Widget? floatingActionButton;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        leading: SvgPicture.asset(logoSvg),
+        leading: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 5.0),
+          child: SvgPicture.asset(
+            logoSvg, height: 100, width: 100,
+          ),
+        ),
         backgroundColor: Colors.white,
         title: Text(
           title,
-          style: const TextStyle(
-            color: Colors.black,
-          ),
+          style: const TextStyle(color: Colors.black),
         ),
       ),
       body: body,

--- a/lib/presentation/shared/app_scaffold.dart
+++ b/lib/presentation/shared/app_scaffold.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter/material.dart';
+
 import 'package:haki_hub/domain/value_objects/asset_strings.dart';
 
 class AppScaffold extends StatelessWidget {
@@ -18,12 +19,14 @@ class AppScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        leading: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 5.0),
-          child: SvgPicture.asset(
-            logoSvg, height: 100, width: 100,
-          ),
-        ),
+        leading: Navigator.canPop(context)
+           ? const BackButton(color: Colors.black)
+           : Padding(
+              padding: const EdgeInsets.symmetric(vertical: 5.0),
+              child: SvgPicture.asset(
+                logoSvg, height: 100, width: 100,
+              ),
+            ),
         backgroundColor: Colors.white,
         title: Text(
           title,

--- a/lib/presentation/shared/info_card.dart
+++ b/lib/presentation/shared/info_card.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_svg/svg.dart';
+// import 'package:flutter_svg/svg.dart';
 import 'package:flutter/material.dart';
 
 import 'package:haki_hub/domain/value_objects/app_colors.dart';
@@ -52,7 +52,8 @@ class InfoCard extends StatelessWidget {
         width: isFullLength
           ? MediaQuery.sizeOf(context).width - 20
           : (MediaQuery.sizeOf(context).width / 2.2),
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+        margin: EdgeInsets.only(bottom: isFullLength ? 10 : 0),
         decoration: BoxDecoration(
           color: hasBorder ? Colors.transparent : backgroundColor,
           borderRadius: BorderRadius.circular(10),
@@ -61,25 +62,21 @@ class InfoCard extends StatelessWidget {
         child: isFullLength
           ? Row(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
+              children: [
                 IconAvatar(
-                  widget: assetName != null
-                    ? SvgPicture.asset(
-                        assetName!,
-                        width: 20,
-                        height: 20,
-                      )
-                    : const SizedBox(),
+                  widget: Icon(
+                    icon,
+                    size: 30,
+                    color: mainColor,
+                  ),
                   isSecondaryColor: isSecondaryColor,
                   isTertiaryColor: isTertiaryColor,
                 ),
-                const SizedBox(
-                  width: 14,
-                ),
-                Flexible(
+                const SizedBox(width: 14),
+                Flexible( 
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
+                    children: [
                       Text(
                         title,
                         style: const TextStyle(
@@ -102,6 +99,7 @@ class InfoCard extends StatelessWidget {
             )
           : Column(
               crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 IconAvatar(
                   widget: Icon(

--- a/lib/presentation/shared/info_card.dart
+++ b/lib/presentation/shared/info_card.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:flutter/material.dart';
+
 import 'package:haki_hub/domain/value_objects/app_colors.dart';
 import 'package:haki_hub/presentation/shared/icon_avatar.dart';
 
@@ -49,8 +50,8 @@ class InfoCard extends StatelessWidget {
       onTap: onTap,
       child: Container(
         width: isFullLength
-            ? MediaQuery.sizeOf(context).width - 20
-            : (MediaQuery.sizeOf(context).width / 2.2),
+          ? MediaQuery.sizeOf(context).width - 20
+          : (MediaQuery.sizeOf(context).width / 2.2),
         padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 10),
         decoration: BoxDecoration(
           color: hasBorder ? Colors.transparent : backgroundColor,
@@ -58,83 +59,77 @@ class InfoCard extends StatelessWidget {
           border: hasBorder ? Border.all(color: borderColor, width: 1) : null,
         ),
         child: isFullLength
-            ? Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  IconAvatar(
-                    widget: assetName != null
-                        ? SvgPicture.asset(
-                            assetName!,
-                            width: 20,
-                            height: 20,
-                          )
-                        : const SizedBox(),
-                    isSecondaryColor: isSecondaryColor,
-                    isTertiaryColor: isTertiaryColor,
-                  ),
-                  const SizedBox(
-                    width: 14,
-                  ),
-                  Flexible(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          title,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                          ),
+          ? Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                IconAvatar(
+                  widget: assetName != null
+                    ? SvgPicture.asset(
+                        assetName!,
+                        width: 20,
+                        height: 20,
+                      )
+                    : const SizedBox(),
+                  isSecondaryColor: isSecondaryColor,
+                  isTertiaryColor: isTertiaryColor,
+                ),
+                const SizedBox(
+                  width: 14,
+                ),
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
                         ),
-                        const SizedBox(
-                          height: 10,
+                      ),
+                      const SizedBox(height: 10),
+                      Text(
+                        description,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.grey[700],
                         ),
-                        Text(
-                          description,
-                          style: TextStyle(
-                            fontSize: 16,
-                            color: Colors.grey[700],
-                          ),
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
-                ],
-              )
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  IconAvatar(
-                    widget: Icon(
-                      icon,
-                      size: 30,
-                      color: mainColor,
-                    ),
-                    isSecondaryColor: isSecondaryColor,
-                    isTertiaryColor: isTertiaryColor,
+                ),
+              ],
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                IconAvatar(
+                  widget: Icon(
+                    icon,
+                    size: 30,
+                    color: mainColor,
                   ),
-                  const SizedBox(
-                    height: 14,
+                  isSecondaryColor: isSecondaryColor,
+                  isTertiaryColor: isTertiaryColor,
+                ),
+                const SizedBox(height: 14),
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
                   ),
-                  Text(
-                    title,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
-                    ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.grey[700],
                   ),
-                  const SizedBox(
-                    height: 10,
-                  ),
-                  Text(
-                    description,
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: Colors.grey[700],
-                    ),
-                  ),
-                ],
-              ),
+                ),
+              ],
+            ),
       ),
     );
   }

--- a/lib/presentation/shared/section_header.dart
+++ b/lib/presentation/shared/section_header.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:haki_hub/domain/value_objects/app_colors.dart';
+
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final String actionText;
+  final VoidCallback? onActionTap;
+  final Color? titleColor;
+  final Color? actionTextColor;
+
+  const SectionHeader({
+    super.key,
+    required this.title,
+    this.actionText = 'View All',
+    this.onActionTap,
+    this.titleColor,
+    this.actionTextColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          GestureDetector(
+            onTap: onActionTap,
+            child: Text(
+              actionText,
+              style: const TextStyle(
+                fontSize: 14,
+                color: AppColors.secondaryColor500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/route_generator.dart
+++ b/lib/routes/route_generator.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:haki_hub/domain/models/content.dart';
-import 'package:haki_hub/presentation/content/pages/update_details_page.dart';
-import 'package:haki_hub/presentation/helplines/pages/ambulance_helpline_page.dart';
-import 'package:haki_hub/presentation/helplines/pages/law_helpline_page.dart';
-import 'package:haki_hub/presentation/helplines/pages/police_helpline_page.dart';
+
 import 'package:haki_hub/routes/routes.dart';
+import 'package:haki_hub/domain/models/content.dart';
+import 'package:haki_hub/presentation/helplines/pages/law_helpline_page.dart';
+import 'package:haki_hub/presentation/content/pages/update_details_page.dart';
+import 'package:haki_hub/presentation/helplines/pages/police_helpline_page.dart';
+import 'package:haki_hub/presentation/helplines/pages/ambulance_helpline_page.dart';
 
 class GenerateRoute {
   static Route<dynamic>? onGenerateRoute(RouteSettings settings) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  fluentui_system_icons:
+    dependency: "direct main"
+    description:
+      name: fluentui_system_icons
+      sha256: "8c37ba0ac30f3fd88026a1d874abfda4e5dfd64ebc3b0dd97719d4d5db65f04a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.244"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   flutter_svg: ^2.0.10+1
   url_launcher: ^6.3.0
+  fluentui_system_icons: ^1.1.244
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. I placed the data in widgets in a custom data structure that can be easily accessed and mapped in the UI. Check out `lib/application/dummy_data.dart`. It is sort of hard scheming through the strings😅.
2. I installed the flutter-ui-icons package to provide icons instead of putting icons in the asset folder. So please do not forget to run `flutter pub get` to install the package. 
3. On the home page, I used grid views and list views to avoid repetition. The same has also been done on the helplines page.
4. I also changed icons for the bottom nav bar.
![Screenshot 2024-06-24 102903](https://github.com/Haki-Hub/haki-hub-mobile/assets/66216041/d890607f-05a2-453d-8aa6-b37a68e5ba0c)
